### PR TITLE
Implementación endpoints Docs Registry API

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,32 @@
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+from typing import List, Optional
+
+app = FastAPI(title="Docs Registry API", docs_url="/swagger")
+
+class Document(BaseModel):
+    id: str
+    name: str
+    type: str
+
+fake_docs_db = [
+    {"id": "1", "name": "Protocolo de Seguridad Runner", "type": "pdf"},
+    {"id": "2", "name": "Arquitectura Hibrida", "type": "docx"},
+]
+
+# --- ENDPOINTS ---
+
+@app.get("/health")
+def read_health():
+    return {"status": "ok", "project": "Runner Factory"}
+
+@app.get("/docs", response_model=List[Document])
+def list_docs():
+    return fake_docs_db
+
+@app.get("/docs/{doc_id}",response_model=Document)
+def read_doc(doc_id:str):
+    for doc in fake_docs_db:
+        if doc["id"] == doc_id:
+            return doc
+        raise HTTPException(status_code = 404, detail="Document not found")

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ fastapi
 uvicorn
 pytest
 ruff
+httpx


### PR DESCRIPTION
Se implementaron los endpoints requeridos para el Issue #2 
* GET /health
* GET /docs 
* GET /docs/{id}
* 
Trazabilidad: Closes #2 

Notas: Se movio la documentación deSwager a /swagger para liberar el endpoint /docs.